### PR TITLE
Replace d3@3 peerDependency with d3-color

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var d3 = require('d3');
+var d3Color = require('d3-color');
 
 function alphaify(color, a) {
-  var c = d3.rgb(color);
+  var c = d3Color.rgb(color);
   return 'rgba(' + [c.r, c.g, c.b] + ', ' + a + ')';
 }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "author": "Victor Powell",
   "license": "ISC",
   "peerDependencies": {
-    "d3": "^3.5.5"
+    "d3-color": "^0.4.2"
+  },
+  "devDependencies": {
+    "d3-color": "^0.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaify",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "repository": "git://github.com/vicapow/alphaify.git",
   "description": "takes a color and sets its alpha.",
   "main": "index.js",


### PR DESCRIPTION
Required for [uber/react-map-gl#34](https://github.com/uber/react-map-gl/issues/34)

This should probably have a version bump before publishing to npm.
