### PR TITLE
Bump d3-color to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "author": "Victor Powell",
   "license": "ISC",
   "peerDependencies": {
-    "d3-color": "^0.4.2"
+    "d3-color": "^1.0.0"
   },
   "devDependencies": {
-    "d3-color": "^0.4.2"
+    "d3-color": "^1.0.0"
   }
 }


### PR DESCRIPTION
Allows peer dependency to be resolved by app that uses d3-color v1.0.0 or higher
